### PR TITLE
Make SugarRecordCDContext initializer public

### DIFF
--- a/library/CoreData/Base/SugarRecordCDContext.swift
+++ b/library/CoreData/Base/SugarRecordCDContext.swift
@@ -21,7 +21,7 @@ public class SugarRecordCDContext: SugarRecordContext
     
     :returns: Initialized SugarRecordCDContext
     */
-    init (context: NSManagedObjectContext)
+    public init (context: NSManagedObjectContext)
     {
         self.contextCD = context
     }


### PR DESCRIPTION
Right now the class is public but the initializer is internal, making it not possible to use it from outside the module and defeating the purpose of making class public.